### PR TITLE
Face-first detection with sharp attention fallback

### DIFF
--- a/SMART_CROP.md
+++ b/SMART_CROP.md
@@ -1,0 +1,80 @@
+# Smart Crop Detection Algorithm
+
+The `csmart` crop mode uses AWS Rekognition to intelligently detect the main subject in an image.
+
+## Algorithm Flow
+
+```
+┌─────────────────────────────────────────┐
+│         AWS Rekognition                 │
+│         Detect Faces                    │
+└─────────────────────────────────────────┘
+                    │
+                    ▼
+            ┌───────────────┐
+            │ Faces found?  │
+            └───────┬───────┘
+                    │
+        ┌───────────┴───────────┐
+        │ NO                    │ YES
+        ▼                       ▼
+┌───────────────┐       ┌───────────────────┐
+│ Sharp         │       │ Largest face ≥5%? │
+│ Attention     │       │ (prominent)       │
+└───────────────┘       └─────────┬─────────┘
+                                  │
+                    ┌─────────────┴─────────────┐
+                    │ YES                       │ NO
+                    ▼                           ▼
+            ┌───────────────┐           ┌───────────────┐
+            │ Use face box  │           │ ≥3 faces?     │
+            │ with padding  │           │ (group photo) │
+            └───────────────┘           └───────┬───────┘
+                                                │
+                                  ┌─────────────┴─────────────┐
+                                  │ YES                       │ NO
+                                  ▼                           ▼
+                          ┌───────────────┐           ┌───────────────┐
+                          │ Use combined  │           │ Sharp         │
+                          │ face box      │           │ Attention     │
+                          └───────────────┘           │ (background)  │
+                                                      └───────────────┘
+```
+
+## Detection Cases
+
+| Case | Condition | Action | Log Example |
+|------|-----------|--------|-------------|
+| **Portrait** | 1 face ≥5% | Face box with padding | `Detection: portrait (1 face, 8.5%)` |
+| **Faces with prominent** | Multiple faces, largest ≥5% | Combined box | `Detection: faces with prominent (3 faces, largest 12.0%)` |
+| **Group photo** | ≥3 faces, all <5% | Combined box | `Detection: group photo (8 faces, largest 2.1%)` |
+| **Background faces** | 1-2 faces, all <5% | Sharp attention | `Detection: background faces (2 faces, 0.5%) → sharp attention` |
+| **No faces** | 0 faces | Sharp attention | `Detection: no faces → sharp attention` |
+| **Error** | API failure | Sharp attention | `Detection: error (message) → sharp attention` |
+
+## Configuration
+
+```javascript
+const FACE_PROMINENCE_THRESHOLD = 5;  // % of image area
+const GROUP_PHOTO_MIN_FACES = 3;      // minimum faces for group photo
+```
+
+## Face Box Padding
+
+When a face is detected, padding is added to include hair and context:
+
+- **Top**: 50% of face height (for hair/head)
+- **Bottom**: 20% of face height
+- **Sides**: 30% of face width
+
+## Fallback: Sharp Attention
+
+When no prominent faces are detected, the system falls back to Sharp's `attention` strategy, which uses libvips to find visually interesting areas (high contrast, edges, colors).
+
+This works well for:
+- Landscapes
+- Architecture
+- Objects
+- Boats
+- Any scene without prominent people
+

--- a/src/crop.js
+++ b/src/crop.js
@@ -1,10 +1,9 @@
 import sharp from 'sharp';
-import { awsDetectSubject } from './aws.js';
-import { log } from './logger.js';
+import { detectSubject } from './detect.js';
 
 export const applyCropSmart = async (imageBuffer, params, metadata) => {
   // Try to detect main subject using Amazon Rekognition
-  const subjectBox = await awsDetectSubject(imageBuffer, metadata);
+  const subjectBox = await detectSubject(imageBuffer, metadata);
 
   if (subjectBox) {
     const cropRect = calculateCropRect(subjectBox, metadata, params);
@@ -21,8 +20,6 @@ export const applyCropSmart = async (imageBuffer, params, metadata) => {
     });
   } else {
     // Fallback to sharp's attention strategy
-    log('No subject detected, using attention strategy');
-
     return sharp(imageBuffer).resize({
       width: params.width,
       height: params.height,

--- a/src/detect.js
+++ b/src/detect.js
@@ -1,0 +1,116 @@
+import sharp from 'sharp';
+import { awsDetectFaces } from './aws.js';
+import { log } from './logger.js';
+
+const FACE_PROMINENCE_THRESHOLD = 5; // percentage of image area
+const GROUP_PHOTO_MIN_FACES = 3;     // minimum faces to consider it a group photo
+
+export const detectSubject = async (imageBuffer, metadata) => {
+  if (metadata.format !== 'jpeg') {
+    imageBuffer = await sharp(imageBuffer).jpeg().toBuffer();
+  }
+
+  const faceBox = await detectFaces(imageBuffer, metadata);
+
+  return faceBox;
+};
+
+const detectFaces = async (imageBuffer, metadata) => {
+  try {
+    const response = await awsDetectFaces(imageBuffer);
+
+    if (!response.FaceDetails || response.FaceDetails.length === 0) {
+      log('Detection: no faces → sharp attention');
+      return null;
+    }
+
+    const imageArea = metadata.width * metadata.height;
+    const faceCount = response.FaceDetails.length;
+
+    // Calculate individual face sizes
+    const faces = response.FaceDetails.map(f => {
+      const box = f.BoundingBox;
+      const area = (box.Width * metadata.width) * (box.Height * metadata.height);
+      const percentage = (area / imageArea) * 100;
+      return { box, area, percentage };
+    });
+
+    const largestFace = Math.max(...faces.map(f => f.percentage));
+
+    // Case 1: Prominent face (portrait or group with main subject)
+    if (largestFace >= FACE_PROMINENCE_THRESHOLD) {
+      if (faceCount === 1) {
+        log(`Detection: portrait (1 face, ${largestFace.toFixed(1)}%)`);
+        return createFaceBox(faces[0].box, metadata);
+      }
+      log(`Detection: faces with prominent (${faceCount} faces, largest ${largestFace.toFixed(1)}%)`);
+      return createCombinedFaceBox(response.FaceDetails, metadata);
+    }
+
+    // Case 2: Many small faces (group photo)
+    if (faceCount >= GROUP_PHOTO_MIN_FACES) {
+      log(`Detection: group photo (${faceCount} faces, largest ${largestFace.toFixed(1)}%)`);
+      return createCombinedFaceBox(response.FaceDetails, metadata);
+    }
+
+    // Case 3: Few small faces - background people
+    log(`Detection: background faces (${faceCount} faces, ${largestFace.toFixed(1)}%) → sharp attention`);
+    return null;
+
+  } catch (error) {
+    const errorMsg = error.message || error.Code || error.name || 'Unknown error';
+    log(`Detection: error (${errorMsg}) → sharp attention`);
+    return null;
+  }
+};
+
+const createFaceBox = (box, metadata) => {
+  const faceBox = {
+    x: box.Left * metadata.width,
+    y: box.Top * metadata.height,
+    width: box.Width * metadata.width,
+    height: box.Height * metadata.height
+  };
+
+  return addPadding(faceBox, metadata);
+};
+
+const createCombinedFaceBox = (faceDetails, metadata) => {
+  let minX = 1, minY = 1, maxX = 0, maxY = 0;
+
+  for (const face of faceDetails) {
+    const box = face.BoundingBox;
+    minX = Math.min(minX, box.Left);
+    minY = Math.min(minY, box.Top);
+    maxX = Math.max(maxX, box.Left + box.Width);
+    maxY = Math.max(maxY, box.Top + box.Height);
+  }
+
+  const faceBox = {
+    x: minX * metadata.width,
+    y: minY * metadata.height,
+    width: (maxX - minX) * metadata.width,
+    height: (maxY - minY) * metadata.height
+  };
+
+  return addPadding(faceBox, metadata);
+};
+
+const addPadding = (faceBox, metadata) => {
+  const paddingTop = faceBox.height * 0.5;
+  const paddingBottom = faceBox.height * 0.2;
+  const paddingHorizontal = faceBox.width * 0.3;
+
+  return {
+    x: Math.max(0, Math.round(faceBox.x - paddingHorizontal)),
+    y: Math.max(0, Math.round(faceBox.y - paddingTop)),
+    width: Math.min(
+      metadata.width - Math.max(0, Math.round(faceBox.x - paddingHorizontal)),
+      Math.round(faceBox.width + paddingHorizontal * 2)
+    ),
+    height: Math.min(
+      metadata.height - Math.max(0, Math.round(faceBox.y - paddingTop)),
+      Math.round(faceBox.height + paddingTop + paddingBottom)
+    )
+  };
+};


### PR DESCRIPTION
## Smart Crop: Face-First Detection Algorithm

### Problem
The previous smart crop implementation using AWS Rekognition labels was unpredictable - it would sometimes focus on irrelevant objects like "Shorts" or "Glasses" instead of the main subject.

### Solution
Simplified the algorithm to focus on **face detection first**, with fallback to Sharp's attention strategy:

| Scenario | Detection | Action |
|----------|-----------|--------|
| **Portrait** | 1 face ≥5% of image | Center on face with padding |
| **Group photo** | ≥3 faces | Center on combined face box |
| **Background people** | 1-2 small faces (<5%) | Sharp attention fallback |
| **No faces** | Landscapes, objects, boats | Sharp attention fallback |

### Why this works better
- **Faces are the priority** - when people are prominent, we never cut their heads
- **Sharp attention is smart** - libvips already does a good job finding focal points for scenes without prominent faces
- **Simple = predictable** - fewer edge cases, easier to understand behavior
