### PR TITLE
Add Lambda support and multi-tenant mode

### DIFF
--- a/Dockerfile.lambda
+++ b/Dockerfile.lambda
@@ -1,0 +1,8 @@
+FROM public.ecr.aws/lambda/nodejs:22
+
+COPY package.json ${LAMBDA_TASK_ROOT}/
+RUN npm install --omit=dev
+
+COPY src ${LAMBDA_TASK_ROOT}/src
+
+CMD ["src/lambda.handler"]

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ Croppix is designed to be integrated into high-performance websites, serving opt
 
 - [🚀 Architecture and Production Deployment](#🚀-architecture-and-production-deployment)
 - [🔧 Features and Quick Start with Docker](#🔧-features-and-quick-start-with-docker)
+- [⚡ AWS Lambda Deployment](#⚡-aws-lambda-deployment)
 - [📂 URL Parameters for Image Transformations](#📂-url-parameters-for-image-transformations)
 - [✂️ Supported Crop Types (`c{crop}`)](#✂️-supported-crop-types-ccrop)
 - [🧑‍💻 Local Development Setup](#🧑‍💻-local-development-setup)
@@ -81,6 +82,105 @@ Croppix is designed to work behind a **CloudFront distribution** with two origin
 - ⚡ Output in WebP, JPEG, PNG and more
 - 🔄 Smart crop, resize, retina scaling, cache busting
 - ⚙ Docker-ready
+
+## ⚡ AWS Lambda Deployment
+
+Croppix can also run as an **AWS Lambda function** using a container image. This is ideal for low-traffic sites where you don't want to maintain a running server — Lambda processes images on-demand and caches them on S3, with near-zero cost after the initial warm-up.
+
+### Lambda Architecture
+
+```
+Client → CloudFront
+           ├── Origin 1 (Primary): S3 cache bucket
+           │   └── Cache hit → serve immediately
+           └── Origin 2 (Fallback on 403/404): Lambda Function URL
+               └── Process image → save to S3 cache → return
+```
+
+After the first request for each image variant, all subsequent requests are served directly from S3 via CloudFront — Lambda is never invoked again.
+
+### Multi-Tenant Mode
+
+When `AWS_BUCKET` is **not set**, Croppix extracts the source bucket name from the first URL path segment. This allows a single Lambda deployment to serve multiple sites:
+
+```
+/<bucket>/<image-path>/<params>.<format>
+```
+
+Example:
+```
+https://your-cloudfront.net/my-site-bucket/images/hero.jpg/w800.webp
+https://your-cloudfront.net/another-site-bucket/photos/pool.jpg/w400.webp
+```
+
+When `AWS_BUCKET` **is set** (e.g., in Docker), the URL format remains unchanged:
+```
+/<image-path>/<params>.<format>
+```
+
+### Building the Lambda Image
+
+```bash
+docker build -f Dockerfile.lambda --provenance=false -t croppix-lambda .
+```
+
+> **Note:** `--provenance=false` is required to produce a Docker v2 manifest compatible with AWS Lambda.
+
+### Deploying to AWS
+
+```bash
+# 1. Create ECR repository (one-time)
+aws ecr create-repository --repository-name croppix
+
+# 2. Login, tag and push
+aws ecr get-login-password | docker login --username AWS --password-stdin <account-id>.dkr.ecr.<region>.amazonaws.com
+docker tag croppix-lambda <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
+docker push <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
+
+# 3. Create Lambda function
+aws lambda create-function \
+  --function-name croppix \
+  --package-type Image \
+  --code ImageUri=<account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest \
+  --role <lambda-role-arn> \
+  --memory-size 1024 \
+  --timeout 60 \
+  --environment "Variables={AWS_BUCKET_CACHE=your-cache-bucket}"
+
+# 4. Create Function URL (public access)
+aws lambda create-function-url-config --function-name croppix --auth-type NONE
+aws lambda add-permission --function-name croppix \
+  --statement-id FunctionURLAllowPublicAccess \
+  --action lambda:InvokeFunctionUrl --principal "*" --function-url-auth-type NONE
+aws lambda add-permission --function-name croppix \
+  --statement-id FunctionURLInvokeAllowPublicAccess \
+  --action lambda:InvokeFunction --principal "*"
+```
+
+Then configure a CloudFront distribution with an **Origin Group** (failover):
+- **Primary**: S3 cache bucket (with Origin Access Control)
+- **Fallback** (on 403/404): Lambda Function URL
+
+### Updating the Lambda
+
+```bash
+docker build -f Dockerfile.lambda --provenance=false -t croppix-lambda .
+docker tag croppix-lambda <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
+docker push <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
+aws lambda update-function-code --function-name croppix \
+  --image-uri <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
+```
+
+### Lambda Environment Variables
+
+| Variable | Required | Description |
+|----------|----------|-------------|
+| `AWS_BUCKET_CACHE` | Yes | S3 bucket for cached processed images |
+| `AWS_BUCKET` | No | Source S3 bucket. If not set, multi-tenant mode is enabled (bucket extracted from URL) |
+
+### AWS Credentials
+
+Croppix uses the default AWS SDK credential chain. On Lambda, credentials are automatically provided by the IAM execution role — no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` needed. In Docker, the SDK reads them from environment variables automatically.
 
 ## 📂 URL Parameters for Image Transformations
 
@@ -209,6 +309,8 @@ AWS_BUCKET_CACHE=your-cache-bucket
 ```
 
 The Docker container will automatically load these variables if referenced in `docker-compose.yml`.
+
+> **Note:** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are read automatically by the AWS SDK from environment variables — they don't need to be passed explicitly in code. On Lambda, the SDK uses the IAM execution role instead.
 
 ### IAM Permissions
 

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,6 @@
 import http from 'http';
 import process from 'process';
-import { parsePath } from './path.js';
-import { processImage } from './process.js';
-import { awsGet, awsPut } from './aws.js';
-import { fetchRemote } from './remote.js';
+import { handleRequest } from './handler.js';
 import { NotFoundError } from './errors.js';
 import { logRequest } from './logger.js';
 
@@ -14,33 +11,13 @@ const options = {
 
 const server = http.createServer(async (req, res) => {
   try {
-    const { sourcePath, isRemote, params } = parsePath(req.url);
-
-    const imageBuffer = isRemote
-      ? await fetchRemote(sourcePath)
-      : await awsGet({
-          Bucket: process.env.AWS_BUCKET,
-          Key: sourcePath
-        });
-
-    const processedImage = await processImage(imageBuffer, params);
-
-    if (!processedImage) {
-      throw new Error('No image data');
-    }
-
-    await awsPut({
-      Bucket: process.env.AWS_BUCKET_CACHE,
-      Key: req.url.substring(1).replace('://', '/'),
-      Body: processedImage,
-      ContentType: 'image/' + params.format
-    });
+    const result = await handleRequest(req.url);
 
     logRequest(200, req.url);
     res.statusCode = 200;
-    res.setHeader('Content-Type', 'image/' + params.format);
+    res.setHeader('Content-Type', result.contentType);
     res.setHeader('Cache-Control', 'public, max-age=31536000, immutable');
-    res.end(Buffer.from(processedImage));
+    res.end(result.buffer);
   } catch (err) {
     if (err instanceof NotFoundError) {
       logRequest(404, req.url, err.message);

--- a/src/aws.js
+++ b/src/aws.js
@@ -3,11 +3,7 @@ import { RekognitionClient, DetectLabelsCommand, DetectFacesCommand } from '@aws
 import { NotFoundError } from './errors.js';
 
 const awsCredentials = {
-  region: process.env.AWS_REGION,
-  credentials: {
-    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
-    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
-  }
+  ...(process.env.AWS_REGION && { region: process.env.AWS_REGION }),
 };
 
 const s3Client = new S3Client(awsCredentials);

--- a/src/handler.js
+++ b/src/handler.js
@@ -1,0 +1,64 @@
+import { parsePath } from './path.js';
+import { processImage } from './process.js';
+import { awsGet, awsPut } from './aws.js';
+import { fetchRemote } from './remote.js';
+import { NotFoundError } from './errors.js';
+
+/**
+ * Extracts the source bucket from the URL when AWS_BUCKET is not set.
+ * URL format: /<bucket>/<source-path>/<params>.<format>
+ * Returns { bucket, imagePath } where imagePath is everything after the bucket.
+ */
+function extractBucket(url) {
+  const bucket = process.env.AWS_BUCKET;
+  if (bucket) {
+    return { bucket, imagePath: url };
+  }
+
+  // First segment is the bucket name
+  const withoutSlash = url.substring(1);
+  const slashIndex = withoutSlash.indexOf('/');
+  if (slashIndex === -1) {
+    throw new NotFoundError('Missing bucket in path');
+  }
+
+  return {
+    bucket: withoutSlash.substring(0, slashIndex),
+    imagePath: '/' + withoutSlash.substring(slashIndex + 1)
+  };
+}
+
+/**
+ * Core request handler shared by HTTP server and Lambda.
+ * @param {string} url - The request URL path
+ * @returns {Promise<{ buffer: Buffer, contentType: string }>}
+ */
+export async function handleRequest(url) {
+  const { bucket, imagePath } = extractBucket(url);
+  const { sourcePath, isRemote, params } = parsePath(imagePath);
+
+  const imageBuffer = isRemote
+    ? await fetchRemote(sourcePath)
+    : await awsGet({
+        Bucket: bucket,
+        Key: sourcePath
+      });
+
+  const processedImage = await processImage(imageBuffer, params);
+
+  if (!processedImage) {
+    throw new Error('No image data');
+  }
+
+  const contentType = 'image/' + params.format;
+  const buffer = Buffer.from(processedImage);
+
+  await awsPut({
+    Bucket: process.env.AWS_BUCKET_CACHE,
+    Key: url.substring(1).replace('://', '/'),
+    Body: processedImage,
+    ContentType: contentType
+  });
+
+  return { buffer, contentType };
+}

--- a/src/lambda.js
+++ b/src/lambda.js
@@ -1,0 +1,38 @@
+import { handleRequest } from './handler.js';
+import { NotFoundError } from './errors.js';
+import { logRequest } from './logger.js';
+
+export async function handler(event) {
+  const url = event.rawPath || event.path || '/';
+
+  try {
+    const result = await handleRequest(url);
+
+    logRequest(200, url);
+    return {
+      statusCode: 200,
+      headers: {
+        'Content-Type': result.contentType,
+        'Cache-Control': 'public, max-age=31536000, immutable'
+      },
+      body: result.buffer.toString('base64'),
+      isBase64Encoded: true
+    };
+  } catch (err) {
+    if (err instanceof NotFoundError) {
+      logRequest(404, url, err.message);
+      return {
+        statusCode: 404,
+        headers: { 'Content-Type': 'text/plain' },
+        body: 'Not found'
+      };
+    }
+
+    logRequest(500, url, err.message);
+    return {
+      statusCode: 500,
+      headers: { 'Content-Type': 'text/plain' },
+      body: 'Internal server error'
+    };
+  }
+}


### PR DESCRIPTION
## Summary
- Extract core processing logic into `handler.js`, shared by HTTP server (`app.js`) and Lambda (`lambda.js`)
- Add `Dockerfile.lambda` for building AWS Lambda container images
- Use default AWS SDK credential chain instead of explicit env vars (supports both Docker with env vars and Lambda with IAM roles)
- Multi-tenant mode: when `AWS_BUCKET` is not set, the source bucket is extracted from the first URL path segment (e.g., `/<bucket>/images/photo.jpg/w400.webp`)

## Breaking changes
None. Existing Docker deployments with `AWS_BUCKET` env var work identically.

## New URL format (multi-tenant)
```
/<bucket>/<source-path>/<params>.<format>
```
Example: `/ondasite-project-villasarahcapri2/images/hero.jpg/w800.webp`

## Test plan
- [ ] Docker: verify existing behavior with `AWS_BUCKET` set
- [ ] Lambda: deploy with `Dockerfile.lambda`, test via Function URL
- [ ] Multi-tenant: test with multiple buckets in URL path
- [ ] Verify S3 cache writes include bucket prefix

🤖 Generated with [Claude Code](https://claude.com/claude-code)