### PR TITLE
Refine documentation and AWS deploy runbook

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,440 @@
+# AWS Deploy Runbook
+
+This document is the operational runbook for deploying Croppix on AWS.
+
+Recommended mode:
+
+- single source bucket with `AWS_BUCKET`
+- one cache bucket with `AWS_BUCKET_CACHE`
+- Lambda container image behind CloudFront
+- CloudFront primary origin: S3 cache bucket
+- CloudFront fallback origin: Lambda Function URL with `AWS_IAM` auth and OAC
+
+## 1. Set Variables
+
+```bash
+export AWS_REGION=<region>
+export ACCOUNT_ID=$(aws sts get-caller-identity --query 'Account' --output text)
+
+export SOURCE_BUCKET=your-source-bucket
+export CACHE_BUCKET=your-cache-bucket
+
+export ECR_REPO=croppix
+export FUNCTION_NAME=croppix
+export ROLE_NAME=croppix-lambda-role
+export POLICY_NAME=croppix-access
+```
+
+## 2. Create the Cache Bucket
+
+```bash
+aws s3 mb "s3://$CACHE_BUCKET" --region "$AWS_REGION"
+
+aws s3api put-public-access-block \
+  --bucket "$CACHE_BUCKET" \
+  --public-access-block-configuration BlockPublicAcls=true,IgnorePublicAcls=true,BlockPublicPolicy=true,RestrictPublicBuckets=true \
+  --region "$AWS_REGION"
+```
+
+`$SOURCE_BUCKET` must already exist and contain the original images.
+
+## 3. Create the Lambda Role
+
+Create the trust policy:
+
+```bash
+cat > trust-policy.json <<'EOF'
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "lambda.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+EOF
+```
+
+Create the role:
+
+```bash
+aws iam create-role \
+  --role-name "$ROLE_NAME" \
+  --assume-role-policy-document file://trust-policy.json
+
+aws iam attach-role-policy \
+  --role-name "$ROLE_NAME" \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole
+```
+
+Create the Croppix access policy:
+
+```bash
+cat > croppix-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::$SOURCE_BUCKET/*"
+      ]
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::$CACHE_BUCKET/*"
+      ]
+    }
+  ]
+}
+EOF
+```
+
+If you want `SMART_CROP_ENGINE=rekognition`, add this statement inside `croppix-policy.json` before applying it:
+
+```json
+{
+  "Effect": "Allow",
+  "Action": [
+    "rekognition:DetectLabels",
+    "rekognition:DetectFaces"
+  ],
+  "Resource": "*"
+}
+```
+
+Apply the inline policy and get the role ARN:
+
+```bash
+aws iam put-role-policy \
+  --role-name "$ROLE_NAME" \
+  --policy-name "$POLICY_NAME" \
+  --policy-document file://croppix-policy.json
+
+export ROLE_ARN=$(aws iam get-role \
+  --role-name "$ROLE_NAME" \
+  --query 'Role.Arn' \
+  --output text)
+```
+
+## 4. Push the Lambda Image to ECR
+
+Create the ECR repository:
+
+```bash
+aws ecr create-repository \
+  --repository-name "$ECR_REPO" \
+  --region "$AWS_REGION"
+```
+
+Croppix publishes the Lambda image on Docker Hub as `asterixcapri/croppix:lambda-latest`.
+
+Lambda container images must be stored in ECR. Mirror the published image into your ECR repository, then continue with the AWS CLI commands below.
+
+```bash
+docker pull asterixcapri/croppix:lambda-latest
+
+aws ecr get-login-password --region "$AWS_REGION" | \
+  docker login --username AWS --password-stdin "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com"
+
+docker tag asterixcapri/croppix:lambda-latest "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO:latest"
+docker push "$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO:latest"
+```
+
+Once the image is in ECR, set:
+
+```bash
+export IMAGE_URI="$ACCOUNT_ID.dkr.ecr.$AWS_REGION.amazonaws.com/$ECR_REPO:latest"
+```
+
+## 5. Create the Lambda Function
+
+Recommended default: single-bucket mode.
+
+```bash
+aws lambda create-function \
+  --function-name "$FUNCTION_NAME" \
+  --package-type Image \
+  --code ImageUri="$IMAGE_URI" \
+  --role "$ROLE_ARN" \
+  --memory-size 1024 \
+  --timeout 60 \
+  --environment "Variables={AWS_BUCKET=$SOURCE_BUCKET,AWS_BUCKET_CACHE=$CACHE_BUCKET}" \
+  --region "$AWS_REGION"
+```
+
+If you want the simplest setup:
+
+```bash
+aws lambda update-function-configuration \
+  --function-name "$FUNCTION_NAME" \
+  --environment "Variables={AWS_BUCKET=$SOURCE_BUCKET,AWS_BUCKET_CACHE=$CACHE_BUCKET,SMART_CROP_ENGINE=attention}" \
+  --region "$AWS_REGION"
+```
+
+If you want Rekognition-based smart crop:
+
+```bash
+aws lambda update-function-configuration \
+  --function-name "$FUNCTION_NAME" \
+  --environment "Variables={AWS_BUCKET=$SOURCE_BUCKET,AWS_BUCKET_CACHE=$CACHE_BUCKET,SMART_CROP_ENGINE=rekognition}" \
+  --region "$AWS_REGION"
+```
+
+## 6. Create the Function URL
+
+```bash
+export FUNCTION_URL=$(aws lambda create-function-url-config \
+  --function-name "$FUNCTION_NAME" \
+  --auth-type AWS_IAM \
+  --region "$AWS_REGION" \
+  --query 'FunctionUrl' \
+  --output text)
+
+export FUNCTION_URL_HOST=${FUNCTION_URL#https://}
+export FUNCTION_URL_HOST=${FUNCTION_URL_HOST%/}
+```
+
+## 7. Create the Origin Access Controls
+
+```bash
+export S3_OAC_ID=$(aws cloudfront create-origin-access-control \
+  --origin-access-control-config Name="croppix-cache-oac",SigningProtocol=sigv4,SigningBehavior=always,OriginAccessControlOriginType=s3 \
+  --query 'OriginAccessControl.Id' \
+  --output text)
+
+export LAMBDA_OAC_ID=$(aws cloudfront create-origin-access-control \
+  --origin-access-control-config Name="croppix-lambda-oac",SigningProtocol=sigv4,SigningBehavior=always,OriginAccessControlOriginType=lambda \
+  --query 'OriginAccessControl.Id' \
+  --output text)
+```
+
+## 8. Create the CloudFront Distribution
+
+Create the distribution config:
+
+```bash
+cat > distribution-config.json <<EOF
+{
+  "CallerReference": "croppix-$(date +%s)",
+  "Comment": "Croppix distribution",
+  "Enabled": true,
+  "Origins": {
+    "Quantity": 2,
+    "Items": [
+      {
+        "Id": "s3-cache-origin",
+        "DomainName": "$CACHE_BUCKET.s3.$AWS_REGION.amazonaws.com",
+        "S3OriginConfig": {
+          "OriginAccessIdentity": ""
+        },
+        "OriginAccessControlId": "$S3_OAC_ID"
+      },
+      {
+        "Id": "lambda-url-origin",
+        "DomainName": "$FUNCTION_URL_HOST",
+        "OriginAccessControlId": "$LAMBDA_OAC_ID",
+        "CustomOriginConfig": {
+          "HTTPPort": 80,
+          "HTTPSPort": 443,
+          "OriginProtocolPolicy": "https-only",
+          "OriginSslProtocols": {
+            "Quantity": 1,
+            "Items": ["TLSv1.2"]
+          }
+        }
+      }
+    ]
+  },
+  "OriginGroups": {
+    "Quantity": 1,
+    "Items": [
+      {
+        "Id": "croppix-origin-group",
+        "FailoverCriteria": {
+          "StatusCodes": {
+            "Quantity": 2,
+            "Items": [403, 404]
+          }
+        },
+        "Members": {
+          "Quantity": 2,
+          "Items": [
+            { "OriginId": "s3-cache-origin" },
+            { "OriginId": "lambda-url-origin" }
+          ]
+        }
+      }
+    ]
+  },
+  "DefaultCacheBehavior": {
+    "TargetOriginId": "croppix-origin-group",
+    "ViewerProtocolPolicy": "redirect-to-https",
+    "AllowedMethods": {
+      "Quantity": 2,
+      "Items": ["GET", "HEAD"],
+      "CachedMethods": {
+        "Quantity": 2,
+        "Items": ["GET", "HEAD"]
+      }
+    },
+    "Compress": true,
+    "ForwardedValues": {
+      "QueryString": false,
+      "Cookies": {
+        "Forward": "none"
+      }
+    },
+    "MinTTL": 0,
+    "DefaultTTL": 86400,
+    "MaxTTL": 31536000
+  }
+}
+EOF
+```
+
+Create the distribution:
+
+```bash
+export DISTRIBUTION_ID=$(aws cloudfront create-distribution \
+  --distribution-config file://distribution-config.json \
+  --query 'Distribution.Id' \
+  --output text)
+
+export CLOUDFRONT_DOMAIN=$(aws cloudfront get-distribution \
+  --id "$DISTRIBUTION_ID" \
+  --query 'Distribution.DomainName' \
+  --output text)
+```
+
+## 9. Allow CloudFront to Reach the Origins
+
+Allow CloudFront to invoke the Lambda Function URL:
+
+```bash
+aws lambda add-permission \
+  --function-name "$FUNCTION_NAME" \
+  --statement-id AllowCloudFrontServicePrincipalInvokeURL \
+  --action lambda:InvokeFunctionUrl \
+  --principal cloudfront.amazonaws.com \
+  --source-arn "arn:aws:cloudfront::$ACCOUNT_ID:distribution/$DISTRIBUTION_ID" \
+  --function-url-auth-type AWS_IAM \
+  --region "$AWS_REGION"
+
+aws lambda add-permission \
+  --function-name "$FUNCTION_NAME" \
+  --statement-id AllowCloudFrontServicePrincipalInvokeFunction \
+  --action lambda:InvokeFunction \
+  --principal cloudfront.amazonaws.com \
+  --source-arn "arn:aws:cloudfront::$ACCOUNT_ID:distribution/$DISTRIBUTION_ID" \
+  --region "$AWS_REGION"
+```
+
+Allow CloudFront to read the cache bucket:
+
+```bash
+cat > cache-bucket-policy.json <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowCloudFrontServicePrincipalReadOnly",
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "cloudfront.amazonaws.com"
+      },
+      "Action": "s3:GetObject",
+      "Resource": "arn:aws:s3:::$CACHE_BUCKET/*",
+      "Condition": {
+        "StringEquals": {
+          "AWS:SourceArn": "arn:aws:cloudfront::$ACCOUNT_ID:distribution/$DISTRIBUTION_ID"
+        }
+      }
+    }
+  ]
+}
+EOF
+
+aws s3api put-bucket-policy \
+  --bucket "$CACHE_BUCKET" \
+  --policy file://cache-bucket-policy.json \
+  --region "$AWS_REGION"
+```
+
+## 10. Wait for Deployment
+
+```bash
+aws cloudfront wait distribution-deployed --id "$DISTRIBUTION_ID"
+```
+
+## 11. Test the Setup
+
+Single-bucket mode:
+
+```text
+https://$CLOUDFRONT_DOMAIN/photos/image123.jpg/w400_h300_csmart.webp
+```
+
+Expected behavior:
+
+1. First request:
+   - S3 cache returns `403` or `404`
+   - CloudFront falls back to Lambda
+   - Croppix reads the source image from `AWS_BUCKET`
+   - Croppix writes the transformed image to `AWS_BUCKET_CACHE`
+2. Second request:
+   - CloudFront serves the cached object from S3
+
+## 12. Update the Lambda Image
+
+Push the new image to the same ECR tag, then run:
+
+```bash
+aws lambda update-function-code \
+  --function-name "$FUNCTION_NAME" \
+  --image-uri "$IMAGE_URI" \
+  --region "$AWS_REGION"
+```
+
+## Multi-Tenant Mode
+
+Multi-tenant mode is optional.
+
+To enable it:
+
+- do not set `AWS_BUCKET`
+- update the Lambda environment to keep only `AWS_BUCKET_CACHE`
+- expand IAM `s3:GetObject` permissions to every source bucket you intentionally allow
+
+Example:
+
+```bash
+aws lambda update-function-configuration \
+  --function-name "$FUNCTION_NAME" \
+  --environment "Variables={AWS_BUCKET_CACHE=$CACHE_BUCKET,SMART_CROP_ENGINE=attention}" \
+  --region "$AWS_REGION"
+```
+
+Multi-tenant request shape:
+
+```text
+https://$CLOUDFRONT_DOMAIN/my-source-bucket/photos/image123.jpg/w400_h300_csmart.webp
+```
+
+Security note:
+
+- in multi-tenant mode, the caller chooses the source bucket via the URL
+- actual access is still limited by the Lambda IAM role
+- keep single-bucket mode as the default unless multi-tenant behavior is intentional
+- in the default setup above, the Lambda Function URL is not public and is intended to be reachable through CloudFront

--- a/README.md
+++ b/README.md
@@ -4,56 +4,16 @@
 [![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](https://www.tldrlegal.com/license/mit-license)
 [![GitHub stars](https://img.shields.io/github/stars/asterixcapri/croppix?style=social)](https://github.com/asterixcapri/croppix)
 
-**Croppix** is an open-source image processing service built on [Sharp](https://sharp.pixelplumbing.com/) and [Amazon Rekognition](https://aws.amazon.com/rekognition/). It generates cropped and optimized images from URL parameters and caches results on AWS S3.
+**Croppix** is an image processing service built on [Sharp](https://sharp.pixelplumbing.com/) and [Amazon Rekognition](https://aws.amazon.com/rekognition/). It generates cropped and optimized images from URL parameters and stores cached results on S3.
 
-Smart crop can use Amazon Rekognition to detect the main subject, rank subject categories from label instances, and refine human subjects with face detection when available.
+`csmart` supports two engines:
 
-The `csmart` crop mode can be switched between two engines with the `SMART_CROP_ENGINE` environment variable: `rekognition` or `attention`.
+- `attention`: simplest setup, no Rekognition needed
+- `rekognition`: subject-aware smart crop with label detection and face refinement
 
-For the full detection flow and thresholds, see [SMART_CROP.md](SMART_CROP.md).
+For the full detection flow, see [SMART_CROP.md](SMART_CROP.md).
 
-Croppix is designed for high-performance websites, serving optimized images through a CDN such as CloudFront with automatic fallback to the processor on cache miss.
-
-## 📦 Distribution
-
-Croppix is published as two Docker image variants under the same Docker Hub repository:
-
-- Standard runtime:
-  - `asterixcapri/croppix:<version>`
-  - `asterixcapri/croppix:latest`
-- AWS Lambda runtime:
-  - `asterixcapri/croppix:<version>-lambda`
-  - `asterixcapri/croppix:lambda-latest`
-
-Docker images are published automatically when a GitHub Release is published.
-
-## 🔍 Table of Contents
-
-- [✅ Recommended Path](#-recommended-path)
-- [⚡ Quick Start](#-quick-start)
-- [🧭 Choosing a Setup](#-choosing-a-setup)
-- [🚀 Architecture and Production Deployment](#🚀-architecture-and-production-deployment)
-- [🔧 Docker Deployment](#-docker-deployment)
-- [⚡ AWS Lambda Deployment](#⚡-aws-lambda-deployment)
-- [📂 URL Parameters for Image Transformations](#📂-url-parameters-for-image-transformations)
-- [✂️ Supported Crop Types (`c{crop}`)](#✂️-supported-crop-types-ccrop)
-- [🧑‍💻 Local Development Setup](#🧑‍💻-local-development-setup)
-- [⚖️ License](#⚖️-license)
-
-## ✅ Recommended Path
-
-If you are evaluating Croppix or deploying it for the first time, start with this setup:
-
-- one S3 bucket for originals: `AWS_BUCKET`
-- one S3 bucket for transformed images: `AWS_BUCKET_CACHE`
-- one Croppix container
-- one CloudFront distribution in front of the cache bucket and Croppix
-- `SMART_CROP_ENGINE=attention` if you want the simplest setup
-- `SMART_CROP_ENGINE=rekognition` if you want subject-aware smart crop
-
-This is the simplest path to production with good cache behavior and minimal moving parts.
-
-### Request Flow
+## How It Works
 
 ```text
 Browser
@@ -67,11 +27,20 @@ CloudFront
                   └─ return image
 ```
 
-## ⚡ Quick Start
+## Try It Locally
 
-This example uses the standard Docker image and one source bucket.
+This is the simplest way to test Croppix locally.
 
-1. Run Croppix:
+### Requirements
+
+- Docker
+- AWS credentials with access to your S3 buckets
+- one source bucket: `AWS_BUCKET`
+- one cache bucket: `AWS_BUCKET_CACHE`
+
+If you want the easiest first run, use `SMART_CROP_ENGINE=attention`.
+
+### Run
 
 ```bash
 docker run -p 3003:3003 \
@@ -84,402 +53,81 @@ docker run -p 3003:3003 \
   asterixcapri/croppix:latest
 ```
 
-2. Request a transformed image:
+### Test Request
+
+Request:
 
 ```text
 http://localhost:3003/photos/image123.jpg/w400_h300_csmart.webp
 ```
 
-The source image must exist in `AWS_BUCKET` at `photos/image123.jpg`.
-
-3. Expected result:
+Expected behavior:
 
 - Croppix reads `photos/image123.jpg` from `AWS_BUCKET`
 - generates a `400x300` WebP
-- stores the processed image in `AWS_BUCKET_CACHE`
+- stores the result in `AWS_BUCKET_CACHE`
 - returns the generated image
+
+The source image must exist in `AWS_BUCKET` at `photos/image123.jpg`.
 
 If you want subject-aware smart crop and have Rekognition permissions configured, switch `SMART_CROP_ENGINE` to `rekognition`.
 
-## 🧭 Choosing a Setup
+## URL Format
 
-| Need | Recommended choice |
-|------|--------------------|
-| Fastest evaluation or simplest setup | Docker + `SMART_CROP_ENGINE=attention` |
-| Best smart crop on people, pets, or clear subjects | Docker or Lambda + `SMART_CROP_ENGINE=rekognition` |
-| Predictable, always-on traffic | Standard Docker deployment |
-| Low traffic or bursty workloads | AWS Lambda deployment |
-| One deployment serving multiple source buckets | Lambda multi-tenant mode |
+A Croppix request looks like this:
 
-## 🚀 Architecture and Production Deployment
-
-Croppix typically runs as a Node.js service behind an Ingress (NGINX or ALB), with original images stored in `AWS_BUCKET` and processed images stored in `AWS_BUCKET_CACHE`.
-
-Docker is the recommended deployment target, usually behind CloudFront.
-
-### 🔄 How it Works in Production
-
-1. A user requests an image from CloudFront, for example:
-
-   ```
-   https://your-cloudfront-distribution.net/photos/image123.jpg/w240_h160_csmart.webp
-   ```
-
-2. CloudFront checks the S3 cache bucket:
-   - ✅ If the image exists, it serves it immediately
-   - 🚫 If it doesn't exist (404 or 403), it falls back to Croppix
-
-3. Croppix receives the request and processes the image:
-   - Fetches it from the source bucket (`AWS_BUCKET`)
-   - Applies the requested transformations
-   - Stores the result in `AWS_BUCKET_CACHE`
-   - Returns the image to CloudFront
-
-4. CloudFront caches the image for future requests
-
-## 🔧 Docker Deployment
-
-Croppix is also available as a Docker container:
-
-👉 [https://hub.docker.com/r/asterixcapri/croppix](https://hub.docker.com/r/asterixcapri/croppix)
-
-Use the standard image when you want a long-running processor behind a load balancer or CDN.
-
-You can run the container with:
-
-```bash
-docker run -p 3003:3003 \
-  -e AWS_ACCESS_KEY_ID=xxx \
-  -e AWS_SECRET_ACCESS_KEY=xxx \
-  -e AWS_REGION=us-east-1 \
-  -e AWS_BUCKET=your-source-bucket \
-  -e AWS_BUCKET_CACHE=your-cache-bucket \
-  asterixcapri/croppix:latest
-```
-
-Croppix is designed to work behind a **CloudFront distribution** with two origins:
-
-1. **Primary origin**: S3 bucket `AWS_BUCKET_CACHE` (with cached processed images)
-2. **Secondary origin (fallback)**: `https://your-croppix-domain.com` (Croppix processor)
-
-### 📊 Architecture Benefits
-
-- 🤖 **AI-powered smart crop** using Rekognition labels, optional face refinement, and Sharp fallback
-- ⚡ High performance via CloudFront + S3
-- 👊 Croppix server is hit only on cache misses
-- 📆 Fully cacheable and URL-customizable images
-- 🚪 Robust system with automatic fallback
-- ✨ On-demand image generation via URL
-- 📁 Integration with AWS S3 for source and cache
-- ⚡ Output in WebP, JPEG, PNG and more
-- 🔄 Smart crop, resize, retina scaling, cache busting
-- ⚙ Docker-ready
-
-## ⚡ AWS Lambda Deployment
-
-Croppix can also run as an **AWS Lambda function** using a container image. This is a good fit for low-traffic sites where you do not want to run a server continuously. Lambda processes images on demand and caches them on S3.
-
-### Lambda Architecture
-
-```
-Client → CloudFront
-           ├── Origin 1 (Primary): S3 cache bucket
-           │   └── Cache hit → serve immediately
-           └── Origin 2 (Fallback on 403/404): Lambda Function URL
-               └── Process image → save to S3 cache → return
-```
-
-After the first request for each image variant, later requests are served directly from S3 via CloudFront, so Lambda is not invoked again for that variant.
-
-### Multi-Tenant Mode
-
-When `AWS_BUCKET` is **not set**, Croppix extracts the source bucket name from the first URL path segment. This allows a single Lambda deployment to serve multiple sites:
-
-```
-/<bucket>/<image-path>/<params>.<format>
-```
-
-Example:
-```
-https://your-cloudfront.net/my-site-bucket/images/hero.jpg/w800.webp
-https://your-cloudfront.net/another-site-bucket/photos/pool.jpg/w400.webp
-```
-
-When `AWS_BUCKET` **is set** (e.g., in Docker), the URL format remains unchanged:
-```
-/<image-path>/<params>.<format>
-```
-
-### Building the Lambda Image
-
-```bash
-docker build -f Dockerfile.lambda --provenance=false -t croppix-lambda .
-```
-
-> **Note:** `--provenance=false` is required to produce a Docker v2 manifest compatible with AWS Lambda.
-
-### Deploying to AWS
-
-```bash
-# 1. Create ECR repository (one-time)
-aws ecr create-repository --repository-name croppix
-
-# 2. Login, tag and push
-aws ecr get-login-password | docker login --username AWS --password-stdin <account-id>.dkr.ecr.<region>.amazonaws.com
-docker tag croppix-lambda <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
-docker push <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
-
-# 3. Create Lambda function
-aws lambda create-function \
-  --function-name croppix \
-  --package-type Image \
-  --code ImageUri=<account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest \
-  --role <lambda-role-arn> \
-  --memory-size 1024 \
-  --timeout 60 \
-  --environment "Variables={AWS_BUCKET_CACHE=your-cache-bucket}"
-
-# 4. Create Function URL (public access)
-aws lambda create-function-url-config --function-name croppix --auth-type NONE
-aws lambda add-permission --function-name croppix \
-  --statement-id FunctionURLAllowPublicAccess \
-  --action lambda:InvokeFunctionUrl --principal "*" --function-url-auth-type NONE
-aws lambda add-permission --function-name croppix \
-  --statement-id FunctionURLInvokeAllowPublicAccess \
-  --action lambda:InvokeFunction --principal "*"
-```
-
-Then configure a CloudFront distribution with an **Origin Group** (failover):
-- **Primary**: S3 cache bucket (with Origin Access Control)
-- **Fallback** (on 403/404): Lambda Function URL
-
-### Updating the Lambda
-
-```bash
-docker build -f Dockerfile.lambda --provenance=false -t croppix-lambda .
-docker tag croppix-lambda <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
-docker push <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
-aws lambda update-function-code --function-name croppix \
-  --image-uri <account-id>.dkr.ecr.<region>.amazonaws.com/croppix:latest
-```
-
-### Lambda Environment Variables
-
-| Variable | Required | Description |
-|----------|----------|-------------|
-| `AWS_BUCKET_CACHE` | Yes | S3 bucket for cached processed images |
-| `AWS_BUCKET` | No | Source S3 bucket. If not set, multi-tenant mode is enabled (bucket extracted from URL) |
-
-### AWS Credentials
-
-Croppix uses the default AWS SDK credential chain. On Lambda, credentials are automatically provided by the IAM execution role — no `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` needed. In Docker, the SDK reads them from environment variables automatically.
-
-## 📂 URL Parameters for Image Transformations
-
-A Croppix image request looks like this:
-
-```
+```text
 https://your-croppix-domain.com/<image-path>/<transform-params>.<format>
 ```
 
-### ✅ Example
+Example:
 
-```
-https://your-croppix-domain.com/photos/image123.jpg/w400_h300_d2_csmart_u1712345678.webp
-```
-
-### Remote Source URLs
-
-Croppix also supports remote source images. In that case, the source URL becomes the image path:
-
-```
-https://your-croppix-domain.com/https://images.example.com/photo.jpg/w800.webp
+```text
+https://your-croppix-domain.com/photos/image123.jpg/w400_h300_d2_csmart.webp
 ```
 
-If the remote source URL contains a query string, the full source URL must be URL-encoded before being embedded into the Croppix path:
+Supported parameters:
 
-```
-https://your-croppix-domain.com/https%3A%2F%2Fimages.example.com%2Fphoto.jpg%3Fw%3D800%26h%3D600/w1200.webp
-```
-
-In multi-tenant mode, the source bucket stays as the first path segment, followed by the encoded remote URL:
-
-```
-https://your-croppix-domain.com/<bucket>/https%3A%2F%2Fimages.example.com%2Fphoto.jpg%3Fw%3D800%26h%3D600/w1200.webp
-```
-
-### Supported Parameters
-
-| Parameter        | Description |
-|------------------|-------------|
-| `w{width}`       | Width in pixels (e.g., `w240`) |
-| `h{height}`      | Height in pixels (e.g., `h160`) |
-| `s{shortSide}`   | Fit to the shortest side |
-| `l{longSide}`    | Fit to the longest side |
-| `c{crop}`        | Crop type (see below) |
-| `q{quality}`     | Output quality (e.g., `q80`) |
-| `d{density}`     | Retina scale factor, e.g., `d2` |
-| `u{updatedAt}`   | Cache busting timestamp (e.g., `u1684485984`) |
-| `.webp`, `.jpeg`, `.png` | Output format |
+| Parameter | Description |
+|-----------|-------------|
+| `w{width}` | Width in pixels |
+| `h{height}` | Height in pixels |
+| `s{shortSide}` | Fit to the shortest side |
+| `l{longSide}` | Fit to the longest side |
+| `c{crop}` | Crop type |
+| `q{quality}` | Output quality |
+| `d{density}` | Retina scale factor |
+| `u{updatedAt}` | Cache busting timestamp |
+| `.webp`, `.jpeg`, `.jpg` | Output format |
 
 Parameters can be combined with `_` and used in any order.
 
-### Validation & HTTP Status Codes
+## Crop Modes
 
-- If the URL is syntactically invalid, the format is not supported, or a parameter is out of range, Croppix returns **404 Not Found**.
-  - Examples: `w{width}` / `h{height}` / `s{shortSide}` / `l{longSide}` > `maxDimension`, `d{density}` outside `[1.0, maxDensity]`, unsupported `c{crop}` or `q{quality}`.
-- If the source image key does not exist in S3, Croppix returns **404 Not Found**.
-- Any internal processing error (Sharp, Rekognition, or other runtime errors) results in **500 Internal Server Error**.
+Croppix supports these values for `c{crop}`:
 
-> **Tip:** To get the original image without any transformations, use `/original`:
-> - `https://your-croppix-domain.com/photos/image123.jpg/original` (same format as source)
+| Value | Description |
+|-------|-------------|
+| `smart` | Smart crop using `attention` or `rekognition`, depending on `SMART_CROP_ENGINE` |
+| `none` | No crop, keep full image with background fill |
+| `entropy` | Sharp entropy strategy |
+| `attention` | Sharp attention strategy |
+| `center` | Center crop |
+| `top` | Top crop |
+| `bottom` | Bottom crop |
+| `left` | Left crop |
+| `right` | Right crop |
+| `leftTop` | Top-left crop |
+| `rightTop` | Top-right crop |
+| `leftBottom` | Bottom-left crop |
+| `rightBottom` | Bottom-right crop |
 
-## ✂️ Supported Crop Types (`c{crop}`)
+## More Docs
 
-Croppix supports the following crop modes via `c{crop}`.
+- [DEPLOY.md](DEPLOY.md): AWS deployment, IAM, Docker production, Lambda
+- [BUILD.md](BUILD.md): build and release commands
+- [SMART_CROP.md](SMART_CROP.md): smart crop internals and thresholds
 
-> **Note:** With `SMART_CROP_ENGINE=rekognition`, the `smart` crop uses Amazon Rekognition `DetectLabels` as the primary signal, ranks known subject categories, merges multi-instance subjects for selected labels, and uses `DetectFaces` only to refine human subjects. If detection fails or no usable subject is found, it falls back to Sharp's `attention` strategy.
-
-> **Engine selection:** set `SMART_CROP_ENGINE=rekognition` or `SMART_CROP_ENGINE=attention` to choose how `csmart` behaves without changing URLs.
-
-| Value        | Description |
-|---------------|----------------------------------------------------------------------------------|
-| `smart`       | AI-powered smart crop using Rekognition labels, optional face refinement, and Sharp fallback |
-| `none`        | No crop: resize and fill with the average background color                      |
-| `entropy`     | Crop area with highest entropy (Sharp)                                          |
-| `attention`   | Crop area with visual attention (Sharp)                                         |
-| `fit`         | Fit image within dimensions without cropping                                    |
-| `center`      | Center crop                                                                     |
-| `top`         | Crop from the top                                                               |
-| `bottom`      | Crop from the bottom                                                            |
-| `left`        | Crop from the left                                                              |
-| `right`       | Crop from the right                                                             |
-| `leftTop`     | Crop from top-left corner                                                       |
-| `rightTop`    | Crop from top-right corner                                                      |
-| `leftBottom`  | Crop from bottom-left corner                                                    |
-| `rightBottom` | Crop from bottom-right corner                                                   |
-
-## ℹ️ Optional JavaScript Example
-
-To generate Croppix URLs in a frontend app:
-
-```js
-const croppixBaseUrl = 'https://your-croppix-domain.com';
-
-export const croppixUrl = (path, params = {}) => {
-  if (!path) return '';
-  const encodedPath = path.startsWith('http://') || path.startsWith('https://')
-    ? '/' + encodeURIComponent(path)
-    : encodeURI(path);
-  return croppixBaseUrl + encodedPath + formatParams(params);
-};
-
-const formatParams = (params = {}) => {
-  const parts = [];
-  if (params?.width) parts.push(`w${params.width}`);
-  if (params?.height) parts.push(`h${params.height}`);
-  if (params?.shortSide) parts.push(`s${params.shortSide}`);
-  if (params?.longSide) parts.push(`l${params.longSide}`);
-  if (params?.crop) parts.push(`c${params.crop}`);
-  if (params?.quality) parts.push(`q${params.quality}`);
-  if (params?.density) parts.push(`d${params.density}`);
-  if (params?.updatedAt) parts.push(`u${params.updatedAt}`);
-
-  if (parts.length === 0) return '/original';
-  return '/' + parts.join('_') + '.' + (params?.format || 'jpeg');
-};
-```
-
-## 🧑‍💻 Local Development Setup
-
-### Requirements
-
-- Docker installed
-- AWS credentials with access to your S3 buckets
-- Two S3 buckets:
-  - `AWS_BUCKET` for original images
-  - `AWS_BUCKET_CACHE` for processed images
-- Amazon Rekognition permissions only if you use `SMART_CROP_ENGINE=rekognition`
-
-Everything else is handled by the provided Docker container.
-
-### Installation and Start
-
-```bash
-git clone https://github.com/asterixcapri/croppix.git
-cd croppix
-cp .env.dist .env
-docker compose up -d
-docker compose exec node bash
-npm install
-npm run dev
-```
-
-### Environment Variables
-
-You can create a `.env` file in the project root with:
-
-```env
-AWS_ACCESS_KEY_ID=your-access-key
-AWS_SECRET_ACCESS_KEY=your-secret-key
-AWS_REGION=your-region
-AWS_BUCKET=your-source-bucket
-AWS_BUCKET_CACHE=your-cache-bucket
-SMART_CROP_ENGINE=rekognition
-```
-
-The Docker container loads these variables automatically if they are referenced in `docker-compose.yml`.
-
-Supported `SMART_CROP_ENGINE` values:
-
-- `rekognition`: Rekognition `DetectLabels` subject detection, optional `DetectFaces` refinement for human subjects, plus Sharp attention fallback
-- `attention`: Sharp's built-in attention strategy only
-
-> **Note:** `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are read automatically by the AWS SDK from environment variables — they don't need to be passed explicitly in code. On Lambda, the SDK uses the IAM execution role instead.
-
-### IAM Permissions
-
-The AWS credentials must have the following permissions:
-
-```json
-{
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Effect": "Allow",
-      "Action": [
-        "s3:GetObject",
-        "s3:PutObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::your-source-bucket/*",
-        "arn:aws:s3:::your-cache-bucket/*"
-      ]
-    },
-    {
-      "Effect": "Allow",
-      "Action": [
-        "rekognition:DetectLabels",
-        "rekognition:DetectFaces"
-      ],
-      "Resource": "*"
-    }
-  ]
-}
-```
-
-The `rekognition:DetectLabels` permission is required when `SMART_CROP_ENGINE=rekognition`. `rekognition:DetectFaces` is additionally required for human-subject refinement.
-
-## 💬 Support & Contributions
-
-Found a bug or want to add a feature?
-
-Open an [Issue](https://github.com/asterixcapri/croppix/issues) or a [Pull Request](https://github.com/asterixcapri/croppix/pulls).
-
-## ⚖️ License
+## License
 
 Distributed under the [MIT license](LICENSE).
-
----
-
-Developed by [Alessandro Astarita](https://github.com/asterixcapri)


### PR DESCRIPTION
## Summary
- simplify the README to focus on the local test flow and core URL/crop usage
- add a dedicated DEPLOY.md runbook for AWS Lambda + CloudFront deployment
- align the docs with the actual smart-crop behavior and supported request options

## Notes
- DEPLOY.md now documents single-bucket mode as the default
- Lambda fallback is documented as CloudFront-only using Function URL `AWS_IAM` auth with OAC
- BUILD.md remains the maintainer-focused build/release reference